### PR TITLE
Change bus status after departure

### DIFF
--- a/src/app/bus/bus.component.ts
+++ b/src/app/bus/bus.component.ts
@@ -38,10 +38,12 @@ export class BusComponent implements OnInit {
           hour: Math.floor(this.bus.departure / 60),
           minute: this.bus.departure % 60
         }).toMillis();
-        const departure = DateTime.fromMillis(departureMs).toLocaleString({
+        const departure = DateTime.fromMillis(departureMs);
+        const departureStr = departure.toLocaleString({
           hour: "numeric", minute: "numeric"
         });
-        return `Departs at ${departure}`;
+        const prefix = DateTime.local() <= departure ? "Departs at" : "Departed at";
+        return `${prefix} ${departureStr}`;
       }
     } else {
       return "Not running";


### PR DESCRIPTION
Currently, when the `departure` field exists, the corresponding bus's status says "Departs at ...". This PR changes that status to "Departed at ..." after the bus's departure time has passed.